### PR TITLE
fix: support dashes in expiration format RFC1123

### DIFF
--- a/lib/cookie_monster/cookie_date_time/parser/rfc1123.ex
+++ b/lib/cookie_monster/cookie_date_time/parser/rfc1123.ex
@@ -12,7 +12,7 @@ defmodule CookieMonster.CookieDateTime.Parser.RFC1123 do
   #                ; day month year (e.g., 02 Jun 1982)
   # time         = 2DIGIT ":" 2DIGIT ":" 2DIGIT
   #                ; 00:00:00 - 23:59:59
-  @regex ~r/\w{3}, (?<day>\d{2}) (?<month>\w{3}) (?<year>\d{4}) (?<hour>\d{2}):(?<minute>\d{2}):(?<second>\d{2}) GMT/
+  @regex ~r/\w{3}, (?<day>\d{2})[\s\-](?<month>\w{3})[\s\-](?<year>\d{4}) (?<hour>\d{2}):(?<minute>\d{2}):(?<second>\d{2}) GMT/
 
   @impl Parser
   def parse(str) do

--- a/test/cookie_monster/decoder_test.exs
+++ b/test/cookie_monster/decoder_test.exs
@@ -51,6 +51,23 @@ defmodule CookieMonster.DecoderTest do
              }
     end
 
+    test "parses cookie string with RFC1123 date but with dashes" do
+      cookie =
+        "HI=hello; expires=Sat, 14-Oct-2023 16:25:57 GMT; path=/; domain=example.com; secure; HttpOnly"
+
+      assert {:ok, cookie} = Decoder.decode(cookie)
+
+      assert cookie == %Cookie{
+               domain: "example.com",
+               expires: ~U[2023-10-14 16:25:57Z],
+               http_only: true,
+               name: "HI",
+               path: "/",
+               secure: true,
+               value: "hello"
+             }
+    end
+
     test "returns an error if invalid cookie was provided" do
       assert {:error, :invalid_cookie} = Decoder.decode("")
     end


### PR DESCRIPTION
Even though I don't believe it is part of the spec, it appears that some
browsers support this format, so adding support for parsing it.

- fix: support dashes in RFC1123
