### PR TITLE
Perform decoding of header even with unsupported directive

### DIFF
--- a/lib/cookie_monster/decoder.ex
+++ b/lib/cookie_monster/decoder.ex
@@ -51,6 +51,7 @@ defmodule CookieMonster.Decoder do
     directives
     |> Enum.map(&normalize_directive/1)
     |> Enum.map(&directive_to_kv_pair/1)
+    |> Enum.reject(&is_nil/1)
     |> Enum.into(%{})
   end
 
@@ -64,6 +65,7 @@ defmodule CookieMonster.Decoder do
   defp directive_to_kv_pair({"secure", true}), do: {:secure, true}
   defp directive_to_kv_pair({"httponly", true}), do: {:http_only, true}
   defp directive_to_kv_pair({"samesite", value}), do: {:same_site, value}
+  defp directive_to_kv_pair(_unsupported_directive), do: nil
 
   defp parse_cookie_values(map) do
     with {:ok, same_site} <- parse_same_site(map[:same_site]),

--- a/test/cookie_monster/decoder_test.exs
+++ b/test/cookie_monster/decoder_test.exs
@@ -81,6 +81,24 @@ defmodule CookieMonster.DecoderTest do
              }
     end
 
+    test "decodes cookie with invalid/unsupported params" do
+      cookie =
+        "secret=VGhhbmsgeW91IGZvciByZWFkaW5nIG15IGNvZGUhIHdhbm5hIGNoYXQ%2FIG1lQGRvcmlhbmthcnRlci5jb20gPGo%3D; Version=1; Unsupported=Value; SameSite=Strict; expires=Tue, 15 Jun 2021 05:32:54 GMT; path=/; secure"
+
+      assert {:ok, cookie} = Decoder.decode(cookie)
+
+      assert cookie == %Cookie{
+               value:
+                 "VGhhbmsgeW91IGZvciByZWFkaW5nIG15IGNvZGUhIHdhbm5hIGNoYXQ%2FIG1lQGRvcmlhbmthcnRlci5jb20gPGo%3D",
+               expires: ~U[2021-06-15 05:32:54Z],
+               path: "/",
+               http_only: nil,
+               name: "secret",
+               secure: true,
+               same_site: :strict
+             }
+    end
+
     test "returns an error if invalid cookie was provided" do
       assert {:error, :invalid_cookie} = Decoder.decode("")
       assert {:error, :invalid_cookie} = Decoder.decode("xyz")


### PR DESCRIPTION
Hi, many thanks for your great work!

I'm currently building a little tool, which analyzes the cookies set by our web applications. One of this web applications (Keycloak) uses the unsupported directive `Version=1;`, which breaks the decoding. Therefore I've added a little fix for that. Unsupported directives will be "rejected" and only supported directives will be adopted.